### PR TITLE
Playback rate fix

### DIFF
--- a/src/kssplay.c
+++ b/src/kssplay.c
@@ -198,7 +198,7 @@ void KSSPLAY_reset(KSSPLAY *kssplay, uint32_t song, uint32_t cpu_speed) {
   kssplay->fade = 0;
   kssplay->fade_flag = 0;
 
-  kssplay->step_inc = kssplay->vm->clock / kssplay->rate;
+  kssplay->step_inc = (double)kssplay->vm->clock / kssplay->rate;
   kssplay->step_cnt = 0;
   kssplay->decoded_length = 0;
   kssplay->silent = 0;

--- a/src/kssplay.c
+++ b/src/kssplay.c
@@ -456,9 +456,12 @@ static inline void fade_per_ch(KSSPLAY *kssplay, KSSPLAY_PER_CH_OUT *out) {
 static inline void process_vm(KSSPLAY *kssplay) {
   int step_int = (int)kssplay->step_cnt;
   kssplay->step_cnt += kssplay->step_inc;
-  if (step_int > 1) {
+  if (step_int > 0) {
     kssplay->step_cnt -= step_int;
-    VM_exec(kssplay->vm, step_int);
+    //VM_exec might execute more than step_int cycles
+    uint32_t extra_cycles = VM_exec(kssplay->vm, step_int) - step_int;
+    //correct the step_cnt for the extra cycles
+    kssplay->step_cnt -= extra_cycles;
   }
 }
 

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -210,7 +210,7 @@ void VM_delete(VM *vm) {
   free(vm);
 }
 
-void VM_exec(VM *vm, uint32_t cycles) { kmz80_exec(&vm->context, cycles); }
+uint32_t VM_exec(VM *vm, uint32_t cycles) { return kmz80_exec(&vm->context, cycles); }
 
 void VM_exec_func(VM *vm, uint32_t func_adr) { exec_setup(vm, func_adr); }
 

--- a/src/vm/vm.h
+++ b/src/vm/vm.h
@@ -84,7 +84,7 @@ void VM_reset(VM *vm, uint32_t cpu_clk, uint32_t pc, uint32_t play_adr, double v
               uint32_t DA8);
 void VM_init_memory(VM *vm, uint32_t ram_mode, uint32_t offset, uint32_t num, uint8_t *data);
 void VM_init_bank(VM *vm, uint32_t mode, uint32_t num, uint32_t offset, uint8_t *data);
-void VM_exec(VM *vm, uint32_t cycles);
+uint32_t VM_exec(VM *vm, uint32_t cycles);
 void VM_exec_func(VM *vm, uint32_t init_adr);
 void VM_set_clock(VM *vm, uint32_t clock, double vsync_freq);
 void VM_set_wioproc(VM *vm, uint32_t a, VM_WIOPROC p);


### PR DESCRIPTION
Hi, thankyou for this great library! I have discovered that the music files converted with kss2vgm resulted in a slightly faster playback (~1.7%) when compared to the KSS files played on nezplug++. I traced back the problem to the current handling of the `kmz80_exec()` calls, which might actually take more Z80 cycles than requested. This difference results in a faster vsync rate and consequently a faster playback speed.

The two commits in this pull request address this issue by:
1. fixing the calculation of `step_inc` so that it represents fractional values.
2. compensating `step_cnt` by the extra cycles calculated from `kmz80_exec()`. This solution is very similar to the way nezplug++ handles the cycle execution.

I have checked the playback rate on a couple of songs from Snatcher which seems to be ok now. Please review and see if this is a good general fix. Thanks!
