### PR TITLE
Per channel pan

### DIFF
--- a/src/kssplay.c
+++ b/src/kssplay.c
@@ -604,6 +604,22 @@ static inline void calc_stereo(KSSPLAY *kssplay, int16_t *buf, uint32_t length) 
           ch[0] += apply_volume(c, volume[KSS_DEVICE_PSG][0]);
           ch[1] += apply_volume(c, volume[KSS_DEVICE_PSG][1]);
         }
+      } else if (kssplay->psg_per_ch_pan) {
+        PSG_RateConv_calc(kssplay->psg_rconv);
+        {
+          int k;
+          PSG *psg = kssplay->vm->psg;
+          for (k = 0; k < 3; k++) {
+            int32_t val = psg->ch_out[k];
+            int32_t pan = kssplay->psg_ch_pan[k];
+            int32_t vl = clip(-256, kssplay->device_volume[KSS_DEVICE_PSG] + kssplay->master_volume + neg(pan), 255);
+            int32_t vr = clip(-256, kssplay->device_volume[KSS_DEVICE_PSG] + kssplay->master_volume + neg(-pan), 255);
+            ch[0] += apply_volume(val, vl);
+            ch[1] += apply_volume(val, vr);
+          }
+          ch[0] += apply_volume(kssplay->vm->DA1, volume[KSS_DEVICE_PSG][0]);
+          ch[1] += apply_volume(kssplay->vm->DA1, volume[KSS_DEVICE_PSG][1]);
+        }
       } else {
         c = FIR_calc(kssplay->device_fir[0][KSS_DEVICE_PSG], PSG_RateConv_calc(kssplay->psg_rconv) + kssplay->vm->DA1);
         ch[0] += apply_volume(c, volume[KSS_DEVICE_PSG][0]);
@@ -612,9 +628,27 @@ static inline void calc_stereo(KSSPLAY *kssplay, int16_t *buf, uint32_t length) 
     }
 
     if (!kssplay->device_mute[KSS_DEVICE_SCC]) {
-      c = FIR_calc(kssplay->device_fir[0][KSS_DEVICE_SCC], SCC_calc(kssplay->vm->scc) + kssplay->vm->DA8);
-      ch[0] += apply_volume(c, volume[KSS_DEVICE_SCC][0]);
-      ch[1] += apply_volume(c, volume[KSS_DEVICE_SCC][1]);
+      if (kssplay->scc_per_ch_pan) {
+        SCC_calc(kssplay->vm->scc);
+        {
+          int k;
+          SCC *scc = kssplay->vm->scc;
+          for (k = 0; k < 5; k++) {
+            int32_t val = scc->ch_out[k];
+            int32_t pan = kssplay->scc_ch_pan[k];
+            int32_t vl = clip(-256, kssplay->device_volume[KSS_DEVICE_SCC] + kssplay->master_volume + neg(pan), 255);
+            int32_t vr = clip(-256, kssplay->device_volume[KSS_DEVICE_SCC] + kssplay->master_volume + neg(-pan), 255);
+            ch[0] += apply_volume(val, vl);
+            ch[1] += apply_volume(val, vr);
+          }
+          ch[0] += apply_volume(kssplay->vm->DA8, volume[KSS_DEVICE_SCC][0]);
+          ch[1] += apply_volume(kssplay->vm->DA8, volume[KSS_DEVICE_SCC][1]);
+        }
+      } else {
+        c = FIR_calc(kssplay->device_fir[0][KSS_DEVICE_SCC], SCC_calc(kssplay->vm->scc) + kssplay->vm->DA8);
+        ch[0] += apply_volume(c, volume[KSS_DEVICE_SCC][0]);
+        ch[1] += apply_volume(c, volume[KSS_DEVICE_SCC][1]);
+      }
     }
 
     /* Check silent span */

--- a/src/kssplay.h
+++ b/src/kssplay.h
@@ -62,6 +62,11 @@ struct tagKSSPLAY {
   int opll_stereo;
 
   PSG_RateConv *psg_rconv;
+
+  int32_t psg_ch_pan[3];  /* per-channel PSG panning (-128..128), 0 = center */
+  int32_t scc_ch_pan[5];  /* per-channel SCC panning (-128..128), 0 = center */
+  uint8_t psg_per_ch_pan; /* enable per-channel PSG panning */
+  uint8_t scc_per_ch_pan; /* enable per-channel SCC panning */
 };
 
 /**


### PR DESCRIPTION
## Motivation

While building an Audacious input plugin for KSS playback, I wanted to spread PSG and SCC channels across the stereo field — similar to how OPLL already supports per-channel panning via KSSPLAY_set_channel_pan and OPLL_setPan.

libkss currently only offers device-level panning for PSG and SCC (KSSPLAY_set_device_pan), which shifts the  entire device left/right as a single unit. The underlying emulators (emu2149, emu2212) already expose per-channel output via ch_out[], but calc_stereo sums them before applying volume and panning.

## Changes

kssplay.h: Added per-channel pan arrays and enable flags to the KSSPLAY struct:

- psg_ch_pan[3] — panning for PSG channels A/B/C (-128..128)
- scc_ch_pan[5] — panning for SCC channels 1-5 (-128..128)
- psg_per_ch_pan / scc_per_ch_pan — enable flags

kssplay.c: Modified calc_stereo to mix channels individually when enabled, reading psg->ch_out[k] and scc->ch_out[k] directly and applying per-channel volume/pan using the same clip/neg/apply_volume pattern as existing device-level mixing. DAC contributions (DA1/DA8) remain at device-level pan. Falls back to the original code path when the flags are unset.

## Example usage

```
kssplay->psg_per_ch_pan = 1;
kssplay->psg_ch_pan[0] = 64;   /* channel A: left */
kssplay->psg_ch_pan[1] = 0;    /* channel B: center */
kssplay->psg_ch_pan[2] = -64;  /* channel C: right */

kssplay->scc_per_ch_pan = 1;
kssplay->scc_ch_pan[0] = 96;   /* spread 5 channels left to right */
kssplay->scc_ch_pan[1] = 48;
kssplay->scc_ch_pan[2] = 0;
kssplay->scc_ch_pan[3] = -48;
kssplay->scc_ch_pan[4] = -96;
```

## Notes

- Zero behavioral change when flags are unset (all fields zero-initialized by existing memset in KSSPLAY_new)
- FIR filtering is bypassed in the per-channel path since it operates on the summed signal; this matches the
default state where FIR is disabled for PSG/SCC
- Pan convention matches device_pan: positive = left, negative = right